### PR TITLE
update for bag recipies

### DIFF
--- a/bags.lua
+++ b/bags.lua
@@ -127,27 +127,27 @@ minetest.register_tool("unified_inventory:bag_large", {
 minetest.register_craft({
 	output = "unified_inventory:bag_small",
 	recipe = {
-		{"",           "group:stick", ""},
-		{"group:wood", "group:wood",    "group:wood"},
-		{"group:wood", "group:wood",    "group:wood"},
+		{"",           "farming:cotton", ""},
+		{"group:wool", "group:wool",     "group:wool"},
+		{"group:wool", "group:wool",     "group:wool"},
 	},
 })
 
 minetest.register_craft({
 	output = "unified_inventory:bag_medium",
 	recipe = {
-		{"",              "",                            ""},
-		{"group:stick", "unified_inventory:bag_small", "group:stick"},
-		{"group:stick", "unified_inventory:bag_small", "group:stick"},
+		{"",               "",                            ""},
+		{"farming:cotton", "unified_inventory:bag_small", "farming:cotton"},
+		{"farming:cotton", "unified_inventory:bag_small", "farming:cotton"},
 	},
 })
 
 minetest.register_craft({
 	output = "unified_inventory:bag_large",
 	recipe = {
-		{"",              "",                             ""},
-		{"group:stick", "unified_inventory:bag_medium", "group:stick"},
-		{"group:stick", "unified_inventory:bag_medium", "group:stick"},
+		{"",               "",                             ""},
+		{"farming:cotton", "unified_inventory:bag_medium", "farming:cotton"},
+		{"farming:cotton", "unified_inventory:bag_medium", "farming:cotton"},
     },
 })
 


### PR DESCRIPTION
when bags was first created, wool and farming were not in minetest_game, and so that people didnt have a load of dependancies I made the recipe from wood and sticks.

now that wool and cotton are available it makes a lot more sense to craft the bags from these items.

they are harder to obtain, but bags are valuable items in game, so i think the extra effort to obtain the items is justified.