### PR TITLE
Allow excluding items made for the circular saw from the recipes list

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,4 +1,4 @@
 creative?
 intllib?
 datastorage?
-
+moreblocks?


### PR DESCRIPTION
The circular saw in the _moreblocks_ mod adds many recipes that take smaller blocks and output a bigger block. This commit adds an option (unified_inventory.exclude_saw_recipes) to not list the recipes of items that are made for the saw. It may be imperfect because the saw items are not very uniquely named.