### PR TITLE
Allow items to exclude their recipes from the recipes list

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -25,7 +25,8 @@ minetest.after(0.01, function()
 						for _,chk in pairs(recipe.items) do
 							local groupchk = string.find(chk, "group:")
 							if (not groupchk and not minetest.registered_items[chk])
-							  or (groupchk and not unified_inventory.get_group_item(string.gsub(chk, "group:", "")).item) then
+							  or (groupchk and not unified_inventory.get_group_item(string.gsub(chk, "group:", "")).item)
+							  or minetest.get_item_group(chk, "exclude_from_craft_guide") ~= 0 then
 								unknowns = true
 							end
 						end


### PR DESCRIPTION
Certain mods add many recipes that take smaller blocks and output a bigger block. This clutters the recipes list. Case in point: the circular saw from the _moreblocks_ mod.

This patch allows mods to tell the craft guide to not include recipes that contain certain items, by setting the group exclude_from_craft_guide = 1 in the items.

This is an alternative, more general approach to that of PR #56. Timing tests indicate no substantial difference in startup time.