### PR TITLE
Add optional farming dependency for bag craft

### DIFF
--- a/bags.lua
+++ b/bags.lua
@@ -214,30 +214,31 @@ minetest.register_tool("unified_inventory:bag_large", {
 })
 
 -- register bag crafts
-minetest.register_craft({
-	output = "unified_inventory:bag_small",
-	recipe = {
-		{"",           "farming:cotton", ""},
-		{"group:wool", "group:wool",     "group:wool"},
-		{"group:wool", "group:wool",     "group:wool"},
-	},
-})
+if minetest.get_modpath("farming") ~= nil then
+	minetest.register_craft({
+		output = "unified_inventory:bag_small",
+		recipe = {
+			{"",           "farming:cotton", ""},
+			{"group:wool", "group:wool",     "group:wool"},
+			{"group:wool", "group:wool",     "group:wool"},
+		},
+	})
 
-minetest.register_craft({
-	output = "unified_inventory:bag_medium",
-	recipe = {
-		{"",               "",                            ""},
-		{"farming:cotton", "unified_inventory:bag_small", "farming:cotton"},
-		{"farming:cotton", "unified_inventory:bag_small", "farming:cotton"},
-	},
-})
+	minetest.register_craft({
+		output = "unified_inventory:bag_medium",
+		recipe = {
+			{"",               "",                            ""},
+			{"farming:cotton", "unified_inventory:bag_small", "farming:cotton"},
+			{"farming:cotton", "unified_inventory:bag_small", "farming:cotton"},
+		},
+	})
 
-minetest.register_craft({
-	output = "unified_inventory:bag_large",
-	recipe = {
-		{"",               "",                             ""},
-		{"farming:cotton", "unified_inventory:bag_medium", "farming:cotton"},
-		{"farming:cotton", "unified_inventory:bag_medium", "farming:cotton"},
-    },
-})
-
+	minetest.register_craft({
+		output = "unified_inventory:bag_large",
+		recipe = {
+			{"",               "",                             ""},
+			{"farming:cotton", "unified_inventory:bag_medium", "farming:cotton"},
+			{"farming:cotton", "unified_inventory:bag_medium", "farming:cotton"},
+	    },
+	})
+end

--- a/depends.txt
+++ b/depends.txt
@@ -1,4 +1,4 @@
 creative?
 intllib?
 datastorage?
-
+farming?


### PR DESCRIPTION
Since the craft recipe for bags contains `farming:cotton`, optional dependeny on `farming` is declared.
And the crafting recipes are skipped if this mod is missing.
No dependency on `wool` since a group is used for this.