### PR TITLE
Attempt to make large crafting recipes displayable

### DIFF
--- a/locale/de.txt
+++ b/locale/de.txt
@@ -46,6 +46,7 @@ All = Alles
 Recipe %s of %s = Rezept %s von %s
 Alternate = Alternative
 Crafting Grid =
+This recipe is too\nlarge to be displayed. = Dieses Rezept ist zu\ngroß, um angezeigt\nzu werden.
 
 ### waypoints.lua ###
 White = Weiß

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -47,6 +47,8 @@ All =
 Recipe %s of %s = 
 Alternate = 
 Crafting Grid =  
+# Shown for huge crafting recipes; try to keep the line length short and use multiple line breaks as needed
+This recipe is too\nlarge to be displayed. = 
 
 ### waypoints.lua ###
 White = 

--- a/register.lua
+++ b/register.lua
@@ -275,23 +275,32 @@ unified_inventory.register_page("craftguide", {
 
 		-- This keeps recipes aligned to the right,
 		-- so that they're close to the arrow.
-		local xoffset = 1.5 + (3 - display_size.width)
+		local xoffset = 5.5
+		-- Offset factor for crafting grids with side length > 4
+		local of = (3/math.max(3, math.max(display_size.width, display_size.height)))
+		-- Size modifier factor
+		local sf = math.min(1, of * 1.5)
+		local bsize = 1.1 * sf
+		-- Ugly hack because for some reason image_buttons don't have the same size as item_image_buttons ...
+		local fakesize = bsize - 0.1
 		for y = 1, display_size.height do
-		for x = 1, display_size.width do
+		for x = display_size.width,1,-1 do
 			local item
 			if craft and x <= craft_width then
 				item = craft.items[(y-1) * craft_width + x]
 			end
+			local xof = (x-1) * of + 1
+			local yof = (y-1) * of + 1
 			if item then
 				formspec = formspec..stack_image_button(
-						xoffset + x, formspecy - 1 + y, 1.1, 1.1,
+						xoffset - xof, formspecy - 1 + yof, bsize, bsize,
 						"item_button_recipe_",
 						ItemStack(item))
 			else
 				-- Fake buttons just to make grid
 				formspec = formspec.."image_button["
-					..tostring(xoffset + x)..","..tostring(formspecy - 1 + y)
-					..";1,1;ui_blank_image.png;;]"
+					..tostring(xoffset - xof)..","..tostring(formspecy - 1 + yof)
+					..";"..fakesize..","..fakesize..";ui_blank_image.png;;]"
 			end
 		end
 		end

--- a/register.lua
+++ b/register.lua
@@ -278,9 +278,21 @@ unified_inventory.register_page("craftguide", {
 		local xoffset = 5.5
 		-- Offset factor for crafting grids with side length > 4
 		local of = (3/math.max(3, math.max(display_size.width, display_size.height)))
+		local od = 0
+		-- Minimum grid size at which size optimazation measures kick in
+		local mini_craft_size = 6
+		if display_size.width >= mini_craft_size then
+			od = math.max(1, display_size.width - 2)
+			xoffset = xoffset - 0.1
+		end
 		-- Size modifier factor
-		local sf = math.min(1, of * 1.05)
-		local bsize = 1.1 * sf
+		local sf = math.min(1, of * (1.05 + 0.05*od))
+		local bsize_h = 1.1 * sf
+		local bsize_w = bsize_h
+		if display_size.width >= mini_craft_size then
+			bsize_w = 1.175 * sf
+		end
+		if (bsize_h > 0.35 and display_size.width) then
 		for y = 1, display_size.height do
 		for x = display_size.width,1,-1 do
 			local item
@@ -291,16 +303,22 @@ unified_inventory.register_page("craftguide", {
 			local yof = (y-1) * of + 1
 			if item then
 				formspec = formspec..stack_image_button(
-						xoffset - xof, formspecy - 1 + yof, bsize, bsize,
+						xoffset - xof, formspecy - 1 + yof, bsize_w, bsize_h,
 						"item_button_recipe_",
 						ItemStack(item))
 			else
 				-- Fake buttons just to make grid
 				formspec = formspec.."image_button["
 					..tostring(xoffset - xof)..","..tostring(formspecy - 1 + yof)
-					..";"..bsize..","..bsize..";ui_blank_image.png;;]"
+					..";"..bsize_w..","..bsize_h..";ui_blank_image.png;;]"
 			end
 		end
+		end
+		else
+			-- Error
+			formspec = formspec.."label["
+				..tostring(2)..","..tostring(formspecy)
+				..";"..minetest.formspec_escape(S("This recipe is too\nlarge to be displayed.")).."]"
 		end
 
 		if craft_type.uses_crafting_grid then

--- a/register.lua
+++ b/register.lua
@@ -321,7 +321,7 @@ unified_inventory.register_page("craftguide", {
 				..";"..minetest.formspec_escape(S("This recipe is too\nlarge to be displayed.")).."]"
 		end
 
-		if craft_type.uses_crafting_grid then
+		if craft_type.uses_crafting_grid and display_size.width <= 3 then
 			formspec = formspec.."label[0,"..(formspecy + 0.9)..";" .. S("To craft grid:") .. "]"
 					.."button[0,  "..(formspecy + 1.5)..";0.6,0.5;craftguide_craft_1;1]"
 					.."button[0.6,"..(formspecy + 1.5)..";0.7,0.5;craftguide_craft_10;10]"

--- a/register.lua
+++ b/register.lua
@@ -287,6 +287,7 @@ unified_inventory.register_page("craftguide", {
 		end
 		-- Size modifier factor
 		local sf = math.min(1, of * (1.05 + 0.05*od))
+		-- Button size
 		local bsize_h = 1.1 * sf
 		local bsize_w = bsize_h
 		if display_size.width >= mini_craft_size then
@@ -294,12 +295,15 @@ unified_inventory.register_page("craftguide", {
 		end
 		if (bsize_h > 0.35 and display_size.width) then
 		for y = 1, display_size.height do
-		for x = display_size.width,1,-1 do
+		for x = 1, display_size.width do
 			local item
 			if craft and x <= craft_width then
 				item = craft.items[(y-1) * craft_width + x]
 			end
-			local xof = (x-1) * of + of
+			-- Flipped x, used to build formspec buttons from right to left
+			local fx = display_size.width - (x-1)
+			-- x offset, y offset
+			local xof = (fx-1) * of + of
 			local yof = (y-1) * of + 1
 			if item then
 				formspec = formspec..stack_image_button(

--- a/register.lua
+++ b/register.lua
@@ -287,7 +287,7 @@ unified_inventory.register_page("craftguide", {
 			if craft and x <= craft_width then
 				item = craft.items[(y-1) * craft_width + x]
 			end
-			local xof = (x-1) * of + 1
+			local xof = (x-1) * of + of
 			local yof = (y-1) * of + 1
 			if item then
 				formspec = formspec..stack_image_button(

--- a/register.lua
+++ b/register.lua
@@ -187,7 +187,7 @@ local function stack_image_button(x, y, w, h, buttonname_prefix, item)
 		selectitem = group_item.sole and displayitem or name
 	end
 	local label = show_is_group and "G" or ""
-	return string.format("item_image_button[%f,%f;%u,%u;%s;%s;%s]",
+	return string.format("item_image_button[%f,%f;%f,%f;%s;%s;%s]",
 			x, y, w, h,
 			minetest.formspec_escape(displayitem),
 			minetest.formspec_escape(buttonname_prefix..unified_inventory.mangle_for_formspec(selectitem)),
@@ -279,10 +279,8 @@ unified_inventory.register_page("craftguide", {
 		-- Offset factor for crafting grids with side length > 4
 		local of = (3/math.max(3, math.max(display_size.width, display_size.height)))
 		-- Size modifier factor
-		local sf = math.min(1, of * 1.5)
+		local sf = math.min(1, of * 1.05)
 		local bsize = 1.1 * sf
-		-- Ugly hack because for some reason image_buttons don't have the same size as item_image_buttons ...
-		local fakesize = bsize - 0.1
 		for y = 1, display_size.height do
 		for x = display_size.width,1,-1 do
 			local item
@@ -300,7 +298,7 @@ unified_inventory.register_page("craftguide", {
 				-- Fake buttons just to make grid
 				formspec = formspec.."image_button["
 					..tostring(xoffset - xof)..","..tostring(formspecy - 1 + yof)
-					..";"..fakesize..","..fakesize..";ui_blank_image.png;;]"
+					..";"..bsize..","..bsize..";ui_blank_image.png;;]"
 			end
 		end
 		end


### PR DESCRIPTION
This is an attempt to fix #68.

The crafting grid buttons are shrinked when craft width or length > 4 so they don't overlap other widgets.

***Do not merge without testing or work!***
This PR is pretty experimental and I am pretty sure it does not work 100%.
The code needs probably some more numbers correct, use better sizes and offsets and especially more testing.
It is not finished, I just leave my code here to study and testing.
One thing which was annoying me extremely was the sad fact that `item_image_button`s don't have the same size as `item_button`s (probably a Minetest bug).

I have tested it for a size of 4 but it doesn't look pretty, the buttons seem to overlap and the item icons appear to be larger than the buttons they are inside.
I have not tested it for any larger size (5×5, 6×6, etc.).