### PR TITLE
Show crafting recipes correctly with size > 3

### DIFF
--- a/locale/de.txt
+++ b/locale/de.txt
@@ -55,6 +55,7 @@ Show next recipe = Nächstes Rezept zeigen
 Show next usage = Nächste Verwendung zeigen
 Show previous recipe = Vorheriges Rezept zeigen
 Show previous usage = Vorherige Verwendung zeigen
+This recipe is too\nlarge to be displayed. = Dieses Rezept ist zu\ngroß, um angezeigt\nzu werden.
 Recipe %d of %d = Rezept %d von %d
 Usage %d of %d = Verwendung %d von %d
 No recipes = Keine Rezepte

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -57,6 +57,8 @@ Show next recipe =
 Show next usage = 
 Show previous recipe = 
 Show previous usage = 
+# Shown for huge crafting recipes; try to keep the line length short and use multiple line breaks as needed
+This recipe is too\nlarge to be displayed. = 
 Recipe %d of %d = 
 Usage %d of %d = 
 No recipes =

--- a/register.lua
+++ b/register.lua
@@ -188,7 +188,7 @@ local function stack_image_button(x, y, w, h, buttonname_prefix, item)
 		selectitem = group_item.sole and displayitem or name
 	end
 	local label = show_is_group and "G" or ""
-	return string.format("item_image_button[%f,%f;%u,%u;%s;%s;%s]",
+	return string.format("item_image_button[%f,%f;%f,%f;%s;%s;%s]",
 			x, y, w, h,
 			minetest.formspec_escape(displayitem),
 			minetest.formspec_escape(buttonname_prefix..unified_inventory.mangle_for_formspec(selectitem)),
@@ -288,10 +288,8 @@ unified_inventory.register_page("craftguide", {
 		-- Offset factor for crafting grids with side length > 4
 		local of = (3/math.max(3, math.max(display_size.width, display_size.height)))
 		-- Size modifier factor
-		local sf = math.min(1, of * 1.5)
+		local sf = math.min(1, of * 1.05)
 		local bsize = 1.1 * sf
-		-- Ugly hack because for some reason image_buttons don't have the same size as item_image_buttons ...
-		local fakesize = bsize - 0.1
 		for y = 1, display_size.height do
 		for x = display_size.width,1,-1 do
 			local item
@@ -309,7 +307,7 @@ unified_inventory.register_page("craftguide", {
 				-- Fake buttons just to make grid
 				formspec = formspec.."image_button["
 					..tostring(xoffset - xof)..","..tostring(formspecy - 1 + yof)
-					..";"..fakesize..","..fakesize..";ui_blank_image.png;;]"
+					..";"..bsize..","..bsize..";ui_blank_image.png;;]"
 			end
 		end
 		end

--- a/register.lua
+++ b/register.lua
@@ -296,7 +296,7 @@ unified_inventory.register_page("craftguide", {
 			if craft and x <= craft_width then
 				item = craft.items[(y-1) * craft_width + x]
 			end
-			local xof = (x-1) * of + 1
+			local xof = (x-1) * of + of
 			local yof = (y-1) * of + 1
 			if item then
 				formspec = formspec..stack_image_button(

--- a/register.lua
+++ b/register.lua
@@ -296,6 +296,7 @@ unified_inventory.register_page("craftguide", {
 		end
 		-- Size modifier factor
 		local sf = math.min(1, of * (1.05 + 0.05*od))
+		-- Button size
 		local bsize_h = 1.1 * sf
 		local bsize_w = bsize_h
 		if display_size.width >= mini_craft_size then
@@ -303,12 +304,15 @@ unified_inventory.register_page("craftguide", {
 		end
 		if (bsize_h > 0.35 and display_size.width) then
 		for y = 1, display_size.height do
-		for x = display_size.width,1,-1 do
+		for x = 1, display_size.width do
 			local item
 			if craft and x <= craft_width then
 				item = craft.items[(y-1) * craft_width + x]
 			end
-			local xof = (x-1) * of + of
+			-- Flipped x, used to build formspec buttons from right to left
+			local fx = display_size.width - (x-1)
+			-- x offset, y offset
+			local xof = (fx-1) * of + of
 			local yof = (y-1) * of + 1
 			if item then
 				formspec = formspec..stack_image_button(

--- a/register.lua
+++ b/register.lua
@@ -284,23 +284,32 @@ unified_inventory.register_page("craftguide", {
 
 		-- This keeps recipes aligned to the right,
 		-- so that they're close to the arrow.
-		local xoffset = 1.5 + (3 - display_size.width)
+		local xoffset = 5.5
+		-- Offset factor for crafting grids with side length > 4
+		local of = (3/math.max(3, math.max(display_size.width, display_size.height)))
+		-- Size modifier factor
+		local sf = math.min(1, of * 1.5)
+		local bsize = 1.1 * sf
+		-- Ugly hack because for some reason image_buttons don't have the same size as item_image_buttons ...
+		local fakesize = bsize - 0.1
 		for y = 1, display_size.height do
-		for x = 1, display_size.width do
+		for x = display_size.width,1,-1 do
 			local item
 			if craft and x <= craft_width then
 				item = craft.items[(y-1) * craft_width + x]
 			end
+			local xof = (x-1) * of + 1
+			local yof = (y-1) * of + 1
 			if item then
 				formspec = formspec..stack_image_button(
-						xoffset + x, formspecy - 1 + y, 1.1, 1.1,
+						xoffset - xof, formspecy - 1 + yof, bsize, bsize,
 						"item_button_recipe_",
 						ItemStack(item))
 			else
 				-- Fake buttons just to make grid
 				formspec = formspec.."image_button["
-					..tostring(xoffset + x)..","..tostring(formspecy - 1 + y)
-					..";1,1;ui_blank_image.png;;]"
+					..tostring(xoffset - xof)..","..tostring(formspecy - 1 + yof)
+					..";"..fakesize..","..fakesize..";ui_blank_image.png;;]"
 			end
 		end
 		end

--- a/register.lua
+++ b/register.lua
@@ -287,9 +287,21 @@ unified_inventory.register_page("craftguide", {
 		local xoffset = 5.5
 		-- Offset factor for crafting grids with side length > 4
 		local of = (3/math.max(3, math.max(display_size.width, display_size.height)))
+		local od = 0
+		-- Minimum grid size at which size optimazation measures kick in
+		local mini_craft_size = 6
+		if display_size.width >= mini_craft_size then
+			od = math.max(1, display_size.width - 2)
+			xoffset = xoffset - 0.1
+		end
 		-- Size modifier factor
-		local sf = math.min(1, of * 1.05)
-		local bsize = 1.1 * sf
+		local sf = math.min(1, of * (1.05 + 0.05*od))
+		local bsize_h = 1.1 * sf
+		local bsize_w = bsize_h
+		if display_size.width >= mini_craft_size then
+			bsize_w = 1.175 * sf
+		end
+		if (bsize_h > 0.35 and display_size.width) then
 		for y = 1, display_size.height do
 		for x = display_size.width,1,-1 do
 			local item
@@ -300,16 +312,22 @@ unified_inventory.register_page("craftguide", {
 			local yof = (y-1) * of + 1
 			if item then
 				formspec = formspec..stack_image_button(
-						xoffset - xof, formspecy - 1 + yof, bsize, bsize,
+						xoffset - xof, formspecy - 1 + yof, bsize_w, bsize_h,
 						"item_button_recipe_",
 						ItemStack(item))
 			else
 				-- Fake buttons just to make grid
 				formspec = formspec.."image_button["
 					..tostring(xoffset - xof)..","..tostring(formspecy - 1 + yof)
-					..";"..bsize..","..bsize..";ui_blank_image.png;;]"
+					..";"..bsize_w..","..bsize_h..";ui_blank_image.png;;]"
 			end
 		end
+		end
+		else
+			-- Error
+			formspec = formspec.."label["
+				..tostring(2)..","..tostring(formspecy)
+				..";"..minetest.formspec_escape(S("This recipe is too\nlarge to be displayed.")).."]"
 		end
 
 		if craft_type.uses_crafting_grid then

--- a/register.lua
+++ b/register.lua
@@ -330,7 +330,7 @@ unified_inventory.register_page("craftguide", {
 				..";"..minetest.formspec_escape(S("This recipe is too\nlarge to be displayed.")).."]"
 		end
 
-		if craft_type.uses_crafting_grid then
+		if craft_type.uses_crafting_grid and display_size.width <= 3 then
 			formspec = formspec.."label[0,"..(formspecy + 0.9)..";" .. F("To craft grid:") .. "]"
 					.."button[0,  "..(formspecy + 1.5)..";0.6,0.5;craftguide_craft_1;1]"
 					.."button[0.6,"..(formspecy + 1.5)..";0.7,0.5;craftguide_craft_10;10]"


### PR DESCRIPTION
Fixes #68. Second attempt.

This shows crafting recipes correctly up to a size of 16×16 (although I don't recommend modders to add such extreme recipes ;-) ). Previously, recipes larger than 3×3 broke UI.
Large recipes simply have smaller buttons.

Recipes larger than 16×16 will not be displayed, for stability reasons. They still appear in the list of alternatives.