### PR TITLE
Show “real” item name AND itemstring in craft result

### DIFF
--- a/register.lua
+++ b/register.lua
@@ -249,6 +249,12 @@ unified_inventory.register_page("craftguide", {
 		formspec = formspec.."listcolors[#00000000;#00000000]"
 		local item_name = unified_inventory.current_item[player_name]
 		if not item_name then return {formspec=formspec} end
+		local item_name_shown
+		if minetest.registered_items[item_name] and minetest.registered_items[item_name].description then
+			item_name_shown = string.format(S("%s (%s)"), minetest.registered_items[item_name].description, item_name)
+		else
+			item_name_shown = item_name
+		end
 
 		local dir = unified_inventory.current_craft_direction[player_name]
 		local rdir
@@ -264,7 +270,7 @@ unified_inventory.register_page("craftguide", {
 
 		formspec = formspec.."background[0.5,"..(formspecy + 0.2)..";8,3;ui_craftguide_form.png]"
 		formspec = formspec.."textarea["..craftresultx..","..craftresulty
-                           ..";10,1;;"..minetest.formspec_escape(F(role_text[dir])..": "..item_name)..";]"
+                           ..";10,1;;"..minetest.formspec_escape(F(role_text[dir])..": "..item_name_shown)..";]"
 		formspec = formspec..stack_image_button(0, formspecy, 1.1, 1.1, "item_button_"
 		                   .. rdir .. "_", ItemStack(item_name))
 


### PR DESCRIPTION
Since my previous PR in which the craft result / craft ingredient showed the real item name instead of the itemstring was rejected, I give it another go, but this time, with a twist:

This PR changes the craft result / craft ingredient label so that it shows _both_ the real name and the itemstring. First the real name is shown, and the itemstring is shown after that in brackets.

Before:

> Result: default:stone

After:

> Result: Stone (default:stone)

If the item has no “name” (`description`), only the itemstring is shown.

If this is merged, issue #70 can be closed.

Possible issue: The text may not fit in small windows for extremely long item names. One example: Minetest Game's screwdriver (since the “name” also includes a comment). On the other hand, I think modders should generally be encouraged to keep item names short.

I still think, in the long run it sucks to abuse the crafting system like this only to learn the itemstring. We should try to figure out a more “clean” approach to expose the itemstring. No matter if it involves Unified Inventory, a different mod, or Minetest itself.
