### PR TITLE
Disable useless main buttons

### DIFF
--- a/internal.lua
+++ b/internal.lua
@@ -107,14 +107,23 @@ function unified_inventory.get_formspec(player, page)
 		end
 
 		if def.type == "image" then
-			formspec[n] = "image_button["
-			formspec[n+1] = ( ui_peruser.main_button_x + 0.65 * (i - 1) - button_col * 0.65 * 4)
-			formspec[n+2] = ","..(ui_peruser.main_button_y + button_row * 0.7)..";0.8,0.8;"
-			formspec[n+3] = minetest.formspec_escape(def.image)..";"
-			formspec[n+4] = minetest.formspec_escape(def.name)..";]"
-			formspec[n+5] = "tooltip["..minetest.formspec_escape(def.name)
-			formspec[n+6] = ";"..(def.tooltip or "").."]"
-			n = n+7
+			if (def.condition == nil or def.condition(player) == true) then
+				formspec[n] = "image_button["
+				formspec[n+1] = ( ui_peruser.main_button_x + 0.65 * (i - 1) - button_col * 0.65 * 4)
+				formspec[n+2] = ","..(ui_peruser.main_button_y + button_row * 0.7)..";0.8,0.8;"
+				formspec[n+3] = minetest.formspec_escape(def.image)..";"
+				formspec[n+4] = minetest.formspec_escape(def.name)..";]"
+				formspec[n+5] = "tooltip["..minetest.formspec_escape(def.name)
+				formspec[n+6] = ";"..(def.tooltip or "").."]"
+				n = n+7
+			else
+				formspec[n] = "image["
+				formspec[n+1] = ( ui_peruser.main_button_x + 0.65 * (i - 1) - button_col * 0.65 * 4)
+				formspec[n+2] = ","..(ui_peruser.main_button_y + button_row * 0.7)..";0.8,0.8;"
+				formspec[n+3] = minetest.formspec_escape(def.image).."^[colorize:#808080:alpha]"
+				n = n+4
+
+			end
 		end
 	end
 

--- a/register.lua
+++ b/register.lua
@@ -59,7 +59,11 @@ unified_inventory.register_button("home_gui_set", {
 		else
 			minetest.chat_send_player(player_name,
 				S("You don't have the \"home\" privilege!"))
+			unified_inventory.set_inventory_formspec(player, unified_inventory.current_page[player_name])
 		end
+	end,
+	condition = function(player)
+		return minetest.check_player_privs(player:get_player_name(), {home=true})
 	end,
 })
 
@@ -77,7 +81,11 @@ unified_inventory.register_button("home_gui_go", {
 		else
 			minetest.chat_send_player(player_name,
 				S("You don't have the \"home\" privilege!"))
+			unified_inventory.set_inventory_formspec(player, unified_inventory.current_page[player_name])
 		end
+	end,
+	condition = function(player)
+		return minetest.check_player_privs(player:get_player_name(), {home=true})
 	end,
 })
 
@@ -97,7 +105,11 @@ unified_inventory.register_button("misc_set_day", {
 		else
 			minetest.chat_send_player(player_name,
 				S("You don't have the settime privilege!"))
+			unified_inventory.set_inventory_formspec(player, unified_inventory.current_page[player_name])
 		end
+	end,
+	condition = function(player)
+		return minetest.check_player_privs(player:get_player_name(), {settime=true})
 	end,
 })
 
@@ -117,7 +129,11 @@ unified_inventory.register_button("misc_set_night", {
 		else
 			minetest.chat_send_player(player_name,
 					S("You don't have the settime privilege!"))
+			unified_inventory.set_inventory_formspec(player, unified_inventory.current_page[player_name])
 		end
+	end,
+	condition = function(player)
+		return minetest.check_player_privs(player:get_player_name(), {settime=true})
 	end,
 })
 
@@ -133,12 +149,16 @@ unified_inventory.register_button("clear_inv", {
 					.." of creative mode to prevent"
 					.." accidental inventory trashing."
 					.."\nUse the trash slot instead."))
+			unified_inventory.set_inventory_formspec(player, unified_inventory.current_page[player_name])
 			return
 		end
 		player:get_inventory():set_list("main", {})
 		minetest.chat_send_player(player_name, S('Inventory cleared!'))
 		minetest.sound_play("trash_all",
 				{to_player=player_name, gain = 1.0})
+	end,
+	condition = function(player)
+		return unified_inventory.is_creative(player:get_player_name())
 	end,
 })
 


### PR DESCRIPTION
![Screenshot of disabled buttons](https://i.imgur.com/GBwJyow.png)

This PR introduces the concept of “disabled” buttons. Each button can now have an optional “condition” field. If set, it must be a function and takes a player as an argument. If the function returns false, the button is disabled and can't be clicked. If the condition is not defined, success is assumed.
IMO this is much better usability, it is very annoying to have so many clickable buttons if most of them are useless because of missing privs or whatever.

Technically, disabled buttons are just grey images which take the place of the real button, as shown in the screenshot. The screenshot shows the button bar of a very unprivileged player (final button comes from a different mod, ignore it). In my opinion, this works out pretty well. :-)

Minor caveats: Whenever the player's privs changed, the inventory formspec is not immediately updated, but only after the next button press. But I think this is an acceptable issue since privileges rarely change, and an update can always be forced by clicking any button.
We have to wait for Minetest to implement `on_grant` and `on_revoke` callbacks, then the buttons could be instantly updated.

PS: Where is the API documentation?