### PR TITLE
Replace exclude_from_craft_guide with not_in_craft_guide

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -27,7 +27,7 @@ minetest.after(0.01, function()
 							local groupchk = string.find(chk, "group:")
 							if (not groupchk and not minetest.registered_items[chk])
 							  or (groupchk and not unified_inventory.get_group_item(string.gsub(chk, "group:", "")).item)
-							  or minetest.get_item_group(chk, "exclude_from_craft_guide") ~= 0 then
+							  or minetest.get_item_group(chk, "not_in_craft_guide") ~= 0 then
 								unknowns = true
 							end
 						end


### PR DESCRIPTION
Unified Inventory's crafting guide is able to filter out certain crafting recipes if the result item has the group `exclude_from_craft_guide` (seen in `api.lua`).
I propose to change the group name to `not_in_craft_guide`.
The reason for this is that this name is already being used by the much older mods `zcg` and `craft_guide` and may soon be added to `craftguide` as well.
So I think it makes sense to adopt this older group name to have at least some form of standardization. :-)

Compability note: Of the hundreds of mods I have installed, I haven't seen a single mod using the `exclude_from_craft_guide` group, so it might be OK to remove support for this group altogether. Probably this is because almost nobody knows this group even exists.
If you're still not sure, you can just add support for both groups instead.